### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,8 @@
  * npm i @versatiles/style
  * ```
  * ```
- * import { colorful } from 'versatiles-style';
- * // OR: const { colorful } = require('versatiles-style');
+ * import { colorful } from '@versatiles/style';
+ * // OR: const { colorful } = require('@versatiles/style');
  * const style = colorful();
  * ```
  * 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@
  *   <body>
  *     <!-- ... -->
  *     <script>
- *       const style = VersatilesStyle.colorful();
+ *       const style = VersaTilesStyle.colorful();
  *       // ...
  *     </script>
  *   </body>


### PR DESCRIPTION
The example code for including the style via a script references a misspelled global, `VersatilesStyle`, which should be `VersaTilesStyle`.